### PR TITLE
Bump to version 0.3 and polish margins surrounding images and galleries

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -12,6 +12,14 @@ A simple blogging theme inspired by dark pastel colours and old style books. Inc
 
 == Changelog ==
 
+= 0.3 =
+* Released: June 1, 2026
+
+- Set the bold heading weight on the `heading` element in `theme.json` rather than repeating it on each individual heading level.
+- Added more breathing room (2rem) around standalone image and gallery blocks. A 2rem step was added to the spacing scale so the value is a reusable preset.
+- Raised the minimum requirements to WordPress 6.9 and PHP 7.4, and updated "Tested up to" to 7.0.
+- Migrated `theme.json` to version 3, keeping the theme's own font-size and spacing presets authoritative via `defaultFontSizes` and `defaultSpacingSizes`.
+
 = 0.2 =
 * Released: October 31, 2023
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Dark Pastel ===
 Contributors: andrewserong
-Requires at least: 6.1
-Tested up to: 6.3
-Requires PHP: 5.6
+Requires at least: 6.9
+Tested up to: 7.0
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ A simple blogging theme inspired by dark pastel colours and old style books. Inc
 * Released: June 1, 2026
 
 - Set the bold heading weight on the `heading` element in `theme.json` rather than repeating it on each individual heading level.
-- Added more breathing room (2rem) around standalone image and gallery blocks. A 2rem step was added to the spacing scale so the value is a reusable preset.
+- Added more breathing room (2rem) around standalone image and gallery blocks.
 - Raised the minimum requirements to WordPress 6.9 and PHP 7.4, and updated "Tested up to" to 7.0.
 - Migrated `theme.json` to version 3, keeping the theme's own font-size and spacing presets authoritative via `defaultFontSizes` and `defaultSpacingSizes`.
 

--- a/style.css
+++ b/style.css
@@ -60,25 +60,6 @@ input[type="submit"],
 }
 
 /*
- * Give standalone images and galleries more breathing room (2rem) than the
- * default 1rem block gap. Scoped to direct children of flow/constrained
- * layouts so images nested inside galleries, columns, etc. keep their own
- * spacing. First/last-child margins are reset so a sole image inside a padded
- * group frame doesn't gain extra space.
- */
-:root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery) {
-	margin-block: var(--wp--preset--spacing--90);
-}
-
-:root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery):first-child {
-	margin-block-start: 0;
-}
-
-:root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery):last-child {
-	margin-block-end: 0;
-}
-
-/*
  * Dark Pastel block styles.
  */
 

--- a/style.css
+++ b/style.css
@@ -4,10 +4,10 @@ Theme URI: https://github.com/andrewserong/dark-pastel-theme
 Author: Andrew Serong
 Author URI: https://andyserong.com
 Description: A simple blogging theme inspired by dark pastel colours and old style books. Includes nine separator block styles for a decorative touch.
-Requires at least: 6.1
-Tested up to: 6.3
-Requires PHP: 5.6
-Version: 0.2
+Requires at least: 6.9
+Tested up to: 7.0
+Requires PHP: 7.4
+Version: 0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: dark-pastel
@@ -57,6 +57,25 @@ input[type="submit"],
 
 .wp-block-image figcaption {
 	color: inherit;
+}
+
+/*
+ * Give standalone images and galleries more breathing room (2rem) than the
+ * default 1rem block gap. Scoped to direct children of flow/constrained
+ * layouts so images nested inside galleries, columns, etc. keep their own
+ * spacing. First/last-child margins are reset so a sole image inside a padded
+ * group frame doesn't gain extra space.
+ */
+:root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery) {
+	margin-block: var(--wp--preset--spacing--90);
+}
+
+:root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery):first-child {
+	margin-block-start: 0;
+}
+
+:root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery):last-child {
+	margin-block-end: 0;
 }
 
 /*

--- a/theme.json
+++ b/theme.json
@@ -54,11 +54,12 @@
 			"wideSize": "1024px"
 		},
 		"spacing": {
+			"defaultSpacingSizes": false,
 			"spacingScale": {
 				"increment": 0.25,
 				"mediumStep": 1,
 				"operator": "+",
-				"steps": 7,
+				"steps": 8,
 				"unit": "rem"
 			},
 			"units": [
@@ -71,6 +72,7 @@
 			]
 		},
 		"typography": {
+			"defaultFontSizes": false,
 			"dropCap": false,
 			"fontFamilies": [
 				{
@@ -308,6 +310,6 @@
 			"title": "Footer (Dark)"
 		}
 	],
-	"version": 2,
-	"$schema": "https://schemas.wp.org/wp/6.1/theme.json"
+	"version": 3,
+	"$schema": "https://schemas.wp.org/wp/6.9/theme.json"
 }

--- a/theme.json
+++ b/theme.json
@@ -59,7 +59,7 @@
 				"increment": 0.25,
 				"mediumStep": 1,
 				"operator": "+",
-				"steps": 8,
+				"steps": 7,
 				"unit": "rem"
 			},
 			"units": [
@@ -146,16 +146,16 @@
 			"core/gallery": {
 				"spacing": {
 					"margin": {
-						"bottom": "var:preset|spacing|90",
-						"top":  "var:preset|spacing|90"
+						"bottom": "2rem",
+						"top":  "2rem"
 					}
 				}
 			},
 			"core/image": {
 				"spacing": {
 					"margin": {
-						"bottom": "var:preset|spacing|90",
-						"top":  "var:preset|spacing|90"
+						"bottom": "2rem",
+						"top":  "2rem"
 					}
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -216,11 +216,15 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
+			"heading": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
 			"h1": {
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--lora)",
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "500",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
 				}
 			},
@@ -228,7 +232,6 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--lora)",
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "500",
 					"lineHeight": "var(--wp--custom--typography--line-height--small)"
 				}
 			},
@@ -236,7 +239,6 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--lora)",
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "500",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
 				}
 			},
@@ -244,7 +246,6 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--lora)",
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "500",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
 				}
 			},
@@ -252,7 +253,6 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--lora)",
 					"fontSize": "var(--wp--preset--font-size--medium)",
-					"fontWeight": "500",
 					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
 					"textTransform": "uppercase"
 				}
@@ -261,7 +261,6 @@
 				"typography": {
 					"fontFamily": "var(--wp--preset--font-family--lora)",
 					"fontSize": "var(--wp--preset--font-size--medium)",
-					"fontWeight": "500",
 					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
 					"textTransform": "uppercase"
 				}

--- a/theme.json
+++ b/theme.json
@@ -128,7 +128,6 @@
 		"useRootPaddingAwareAlignments": true
 	},
 	"styles": {
-		"css": "/* Standalone images and galleries get more breathing room (2rem) than the default 1rem block gap; a Block Spacing value set on a parent Group still wins, since per-container gaps are emitted later in the cascade. */ :root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery){margin-block:var(--wp--preset--spacing--90)} :root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery):first-child{margin-block-start:0} :root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery):last-child{margin-block-end:0}",
 		"blocks": {
 			"core/button": {
 				"border": {
@@ -142,6 +141,22 @@
 					"fontFamily": "var(--wp--preset--font-family--lora)",
 					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontWeight": "normal"
+				}
+			},
+			"core/gallery": {
+				"spacing": {
+					"margin": {
+						"bottom": "var:preset|spacing|90",
+						"top":  "var:preset|spacing|90"
+					}
+				}
+			},
+			"core/image": {
+				"spacing": {
+					"margin": {
+						"bottom": "var:preset|spacing|90",
+						"top":  "var:preset|spacing|90"
+					}
 				}
 			},
 			"core/paragraph": {

--- a/theme.json
+++ b/theme.json
@@ -128,6 +128,7 @@
 		"useRootPaddingAwareAlignments": true
 	},
 	"styles": {
+		"css": "/* Standalone images and galleries get more breathing room (2rem) than the default 1rem block gap; a Block Spacing value set on a parent Group still wins, since per-container gaps are emitted later in the cascade. */ :root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery){margin-block:var(--wp--preset--spacing--90)} :root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery):first-child{margin-block-start:0} :root :where(.is-layout-flow, .is-layout-constrained) > :where(figure.wp-block-image, figure.wp-block-gallery):last-child{margin-block-end:0}",
 		"blocks": {
 			"core/button": {
 				"border": {


### PR DESCRIPTION
This is a small yet opinionated change:

* Updates the `theme.json` version to `3` while switching off default spacing and typography sizes (as this theme uses its own opinionated sizes)
* Adds `2rem` vertical margins on image and gallery blocks. This theme uses quite a simple / blocky vertical rhythm, and so 2 x `1rem` feels like the right vertical spacing to give images and galleries a bit more breathing room.
* Move font weight up to `heading` so it can more easily be overridden